### PR TITLE
Update 1Fees System.md

### DIFF
--- a/developer/Fees/1Fees System.md
+++ b/developer/Fees/1Fees System.md
@@ -13,7 +13,7 @@ After paying fees, the Relayer will estimate whether these fees can cover the co
 
 ## Fee Rules
 
-Teleport charge these fees to cover the gas spend on the destination Chains, if the destination chains is Teleport Chain, we provide free relay, for detail fee rules, please check the following:
+Teleport charges these fees to cover the gas spent on the destination chains, if the destination chain is Teleport Chain, we provide free relay. For more detailed fee rules, please check the following:
 
 
 
@@ -25,4 +25,4 @@ The fees are based on the gas cost by custom contract calls and the current gas 
 
 When integrating with the [official bridge](https://bridge.testnet.teleport.network/), you can use our [API]() to estimate the cost. 
 
-When integrating directly with our XIBC contracts, the cost is based on the actions the user application wants to perform on the destination chain, developers need to estimate the expense by themself at the current stage, we will open an API to help with this soon.
+When integrating directly with our XIBC contracts, the cost is based on the actions the user application wants to perform on the destination chain, developers need to estimate the expense themselves as of now; however, we will open an API to help with this soon.


### PR DESCRIPTION
Teleport charges these fees to cover the gas spent on the destination chains, if the destination chain is Teleport Chain, we provide free relay, for detailed fee rules, please check the following:
 

- There is nothing following this ^^^^^